### PR TITLE
dsGit: fix mapper_parsing_exception error

### DIFF
--- a/dsgit.go
+++ b/dsgit.go
@@ -2463,7 +2463,7 @@ func (j *DSGit) PairProgrammingMetrics(ctx *Ctx, rich, commit map[string]interfa
 		if !ok {
 			continue
 		}
-		rich[flag] = flag
+		rich[flag] = 1
 		iAuthors, _ := Dig(commit, []string{authorsKey}, true, false)
 		rich[authorsKey] = iAuthors
 		authors, _ := iAuthors.([]string)

--- a/dsgit.go
+++ b/dsgit.go
@@ -2496,6 +2496,7 @@ func (j *DSGit) PairProgrammingMetrics(ctx *Ctx, rich, commit map[string]interfa
 	rich["pair_programming_lines_added"] = ppLinesAdded
 	rich["pair_programming_lines_removed"] = ppLinesRemoved
 	rich["pair_programming_lines_changed"] = ppLinesChanged
+	rich["is_pair_programming_commit"] = 1
 	if ctx.Debug > 2 {
 		Printf("(%d,%d,%d,%d,%f,%f,%f,%f,%f)\n", files, linesAdded, linesRemoved, linesChanged, ppCount, ppFiles, ppLinesAdded, ppLinesRemoved, ppLinesChanged)
 	}


### PR DESCRIPTION
found lots of these errors in the logs:

```
{
  "error": {
    "root_cause": [
      {
        "type": "mapper_parsing_exception",
        "reason": "failed to parse field [is_git_commit_co_author] of type [long] in document with id '93072b9e89d4c309f35e72f60ee0f71b6c6c2013_3'. Preview of field's value: 'is_git_commit_co_author'"
      }
    ],
    "type": "mapper_parsing_exception",
    "reason": "failed to parse field [is_git_commit_co_author] of type [long] in document with id '93072b9e89d4c309f35e72f60ee0f71b6c6c2013_3'. Preview of field's value: 'is_git_commit_co_author'",
    "caused_by": {
      "type": "illegal_argument_exception",
      "reason": "For input string: \"is_git_commit_co_author\""
    }
  },
  "status": 400
} after 9 seconds
```

turns out we were assigning string values to fields that are of type long in the es mapping.