### PR TITLE
DA-4518: remove file_data object from git enriched documents

### DIFF
--- a/dsgit.go
+++ b/dsgit.go
@@ -2423,6 +2423,7 @@ func (j *DSGit) EnrichItem(ctx *Ctx, item map[string]interface{}, skip string, a
 		}
 	}
 	//rich["file_data"] = fileData
+	rich["files_changed"] = len(fileData)
 	rich["files"] = nFiles
 	rich["lines_added"] = linesAdded
 	rich["lines_removed"] = linesRemoved

--- a/dsgit.go
+++ b/dsgit.go
@@ -2422,7 +2422,7 @@ func (j *DSGit) EnrichItem(ctx *Ctx, item map[string]interface{}, skip string, a
 			}
 		}
 	}
-	rich["file_data"] = fileData
+	//rich["file_data"] = fileData
 	rich["files"] = nFiles
 	rich["lines_added"] = linesAdded
 	rich["lines_removed"] = linesRemoved


### PR DESCRIPTION
We are running into this issue alot:
```
ES bulk upload error: (243521): map[errors:true items:[map[index:map[_id:eedeba940abf3f958b43b217466a9364c584bbfd _index:sds-o3de-o3de-project-git _primary_term:21 _seq_no:1.007166e+06 _shards:map[failed:0 successful:5 total:5] _type:_doc _version:1 forced_refresh:true result:created status:201]] map[index:map[_id:1bbe7a03e47e1542cb4148739ab331f78151804d _index:sds-o3de-o3de-project-git _type:_doc error:map[reason:The number of nested documents has exceeded the allowed limit of [10000]. This limit can be set by changing the [i(...)]] map[index:map[_id:9f4292b853bf023f1a670b3f6b547b4b8eb63486 _index:sds-o3de-o3de-project-git _primary_term:21 _seq_no:1.008163e+06 _shards:map[failed:0 successful:5 total:5] _type:_doc _version:1 forced_refresh:true result:created status:201]] map[index:map[_id:67770d897f8a0c075c4cd31cf8f439a9ccd9a538 _index:sds-o3de-o3de-project-git _primary_term:21 _seq_no:1.008164e+06 _shards:map[failed:0 successful:5 total:5] _type:_doc _version:1 forced_refresh:true result:created status:201]]] took:1939]
```

The problem is that the `file_data` object can contain hundreds of thousands of nested objects as shown in the screenshot below:
![Screen Shot 2021-11-11 at 9 31 55 PM](https://user-images.githubusercontent.com/81646015/141352550-1029a126-f404-4f0d-ab4a-788a0a04e30c.png)

We don't use any of this data for aggregations so we can remove this object from the enriched documents.

Signed-off-by: Ibrahim <dev.code.ibra@gmail.com>